### PR TITLE
Add tests of utils.safe_apply_template function and refactor it

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from utils import safe_apply_template
+from untei.utils import safe_apply_template
 
 
 class TestUtils(unittest.TestCase):

--- a/untei/constants.py
+++ b/untei/constants.py
@@ -12,7 +12,7 @@ def _path_concatinate(p1, p2):
 
 class Const:
     # arguments
-    FILES_PATH = sys.argv[1] + "/"
+    FILES_PATH = sys.argv[1] + "/" if len(sys.argv) > 1 else "./"
     # Essential file names
     OUTPUT_DIRECTORY =  _path_concatinate(FILES_PATH, "output/")
     SITE_CONFIG_PATH  = _path_concatinate(FILES_PATH, "theme/site_config.txt")

--- a/untei/test_utils.py
+++ b/untei/test_utils.py
@@ -1,0 +1,80 @@
+import unittest
+from utils import safe_apply_template
+
+
+class TestUtils(unittest.TestCase):
+    def test_safe_apply_template_unsafe_case1(self):
+        template = \
+            """
+            <h1>page title</h1>
+            <p>your body</p>
+            <<footer>>
+            """
+
+        assignment_dict = {
+            "title": "TEST TITLE",
+            "body": "TEST title BODY", # not safe
+            "footer": "End!"
+        }
+
+        expected = \
+            """
+            <h1>page TEST TITLE</h1>
+            <p>your TEST title BODY</p>
+            <<End!>>
+            """
+
+        actual = safe_apply_template(template, assignment_dict)
+        self.assertEqual(expected, actual)
+
+    def test_safe_apply_template_unsafe_case2(self):
+        template = \
+            """
+            <h1>page title</h1>
+            <p>your body</p>
+            <<footer>>
+            """
+
+        assignment_dict = {
+            "title": "TEST body TITLE", # not safe
+            "body": "TEST BODY",
+            "footer": "End!"
+        }
+
+        expected = \
+            """
+            <h1>page TEST body TITLE</h1>
+            <p>your TEST BODY</p>
+            <<End!>>
+            """
+
+        actual = safe_apply_template(template, assignment_dict)
+        self.assertEqual(expected, actual)
+
+    def test_safe_apply_template_safe_case1(self):
+        template = \
+            """
+            <h1>page title</h1>
+            <p>your body</p>
+            <<footer>>
+            """
+
+        assignment_dict = {
+            "title": "TEST TITLE SAFE",
+            "body": "TEST BODY SAFE",
+            "footer": "End!"
+        }
+
+        expected = \
+            """
+            <h1>page TEST TITLE SAFE</h1>
+            <p>your TEST BODY SAFE</p>
+            <<End!>>
+            """
+
+        actual = safe_apply_template(template, assignment_dict)
+        self.assertEqual(expected, actual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/untei/utils.py
+++ b/untei/utils.py
@@ -21,24 +21,21 @@ def is_uncopied(filename):
 
 def safe_apply_template(template, assignment_dict):
     safe_assignment_dict = {}
-    for check_key in assignment_dict.keys():
-        for key in assignment_dict.keys():
-            if key in assignment_dict[check_key]:
-                # create a temporary key
-                while True:
-                    temp_key = str(random.random())
-                    if not(temp_key in assignment_dict[key]) and not(temp_key in template):
-                        break
-
-                # Evacuation
-                safe_assignment_dict[temp_key] = key
-                assignment_dict[check_key] = assignment_dict[check_key].replace(key, temp_key)
-            else:
-                pass
+    for key, val in assignment_dict.items():
+        if any(k in val for k in assignment_dict.keys()):
+            tmp_uniq = generate_uniq_str(template, assignment_dict, safe_assignment_dict)
+            # Evacuation
+            assignment_dict[key] = assignment_dict[key].replace(val, tmp_uniq)
+            safe_assignment_dict[tmp_uniq] = val
     rep = replace_with_dict(template, assignment_dict)
     rep = replace_with_dict(rep, safe_assignment_dict)
     return rep
 
+def generate_uniq_str(template, assignment_dict, safe_assignment_dict):
+    while True:
+        ret_uniq = str(random.random())
+        if ret_uniq not in template and ret_uniq not in assignment_dict.keys() and ret_uniq not in safe_assignment_dict.keys():
+            return ret_uniq
 
 def replace_with_dict(target, assignment_dict):
     rep = target


### PR DESCRIPTION
Hi, yaufai.
untei project is very exciting! Let me contribute to this project.

In this PR, I focused on utils.safe_apply_template function. (It's so interesting for me.)
I added unit tests as `untei/test_utils.py` and also refactored `safe_apply_template` func.

### [Note] how to run test

To run tests in local, I believe you should remove `untei.` in https://github.com/yaufai/untei/blob/master/untei/utils.py#L4
I didn't modify it because it affects the product codes.
and run

```
$ python3 untei/test_utils.py
```

I think untei has an issue about reference. It seems untei in development refers to untei installed by `pip3 install untei`.